### PR TITLE
Add support for C++ comments, fix newlines in comments

### DIFF
--- a/nslocalized/store.py
+++ b/nslocalized/store.py
@@ -28,7 +28,7 @@ _c_escapes = {
     'v': '\x0b'
 }
     
-_start_re = re.compile(r'\s*(?:/\*|")')
+_start_re = re.compile(r'\s*(?:/\*|//|")')
 _comment_re = re.compile(r'\*/')
 _exp_key_re = re.compile(r'\s*"')
 _key_re = re.compile(r'(?:\\|")')
@@ -206,6 +206,14 @@ class StringTable(object):
                             state = IN_COMMENT
                             chunks = []
                             pos = m.end(0)
+                            skip_nl = True
+                        elif m.group(0) == '//':
+                            comment_content = line[m.end(0):].strip()
+                            if comment is None:
+                                comment = comment_content
+                            else:
+                                comment += ' ' + comment_content
+                            pos = end
                         elif m.group(0) == '"':
                             state = IN_KEY
                             chunks = []
@@ -219,7 +227,8 @@ class StringTable(object):
                     if m:
                         state = EXPECTING_KEY
                         chunks.append(line[pos:m.start(0)].strip())
-                        comment = ''.join(chunks)
+                        comment = ' '.join(chunks).strip()
+                        skip_nl = False
                     else:
                         chunks.append(line[pos:].strip())
                         pos = end

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -92,3 +92,44 @@ def test_writing():
             s2 = StringTable.read(f)
 
             assert st == s2
+
+def test_comments():
+    """Test that comments are parsed properly."""
+    text = '''\
+/* This is a C-style comment which goes over
+   multiple lines */
+"A" = "A";
+
+/* This is a C-style comment with a
+/* nested start
+   comment */
+"B" = "B";
+
+/* This is a C-style comment with what looks like a key inside
+"NotAKey" = "NotAValue";
+*/
+"C" = "C";
+
+// This is a C++-style comment
+"D" = "D";
+
+// This C++-style comment goes over
+// multiple lines
+"E" = "E";
+
+"ThisHasNoComment" = "NoComment";
+'''
+    with io.BytesIO(text.encode('utf_8')) as f:
+        st = StringTable.read(f)
+    assert st['A'] == 'A'
+    assert st.lookup('A').comment == 'This is a C-style comment which goes over multiple lines'
+    assert st['B'] == 'B'
+    assert st.lookup('B').comment == 'This is a C-style comment with a /* nested start comment'
+    assert st['C'] == 'C'
+    assert st.lookup('C').comment == 'This is a C-style comment with what looks like a key inside "NotAKey" = "NotAValue";'
+    assert st['D'] == 'D'
+    assert st.lookup('D').comment == 'This is a C++-style comment'
+    assert st['E'] == 'E'
+    assert st.lookup('E').comment == 'This C++-style comment goes over multiple lines'
+    assert st['ThisHasNoComment'] == 'NoComment'
+    assert st.lookup('ThisHasNoComment').comment is None


### PR DESCRIPTION
This extends the comment parser to support C++ style comments before key-value pairs, along with tests.