### PR TITLE
Make "/* No description */" comment optional (and off by default)

### DIFF
--- a/nslocalized/store.py
+++ b/nslocalized/store.py
@@ -71,8 +71,9 @@ class LocalizedString(object):
         return '%r' % self.target
     
 class StringTable(object):
-    def __init__(self):
+    def __init__(self, include_empty_comments=False):
         self.strings = {}
+        self.include_empty_comments = include_empty_comments
 
     def __eq__(self, other):
         return self.strings == other.strings
@@ -298,7 +299,7 @@ class StringTable(object):
             ls = self.strings[k]
             if ls.comment:
                 writer.write('/* %s */\n' % ls.comment)
-            else:
+            elif self.include_empty_comments:
                 writer.write('/* No description */\n')
 
             if escape_strings:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -92,3 +92,29 @@ def test_writing():
             s2 = StringTable.read(f)
 
             assert st == s2
+
+def test_include_empty_comments():
+    """Test writing and not writing empty comments."""
+    text = '''\
+"A" = "A";
+'''
+
+    text_with_empty_comments = '''\
+/* No description */
+"A" = "A";
+'''
+    with io.BytesIO(text.encode('utf_8')) as f:
+        st = StringTable.read(f)
+
+    with io.BytesIO() as f:
+        st.write(f, encoding='utf-8')
+        f.seek(0)
+        text2 = f.read().decode('utf-8')
+        assert text == text2
+
+    with io.BytesIO() as f:
+        st.include_empty_comments = True
+        st.write(f, encoding='utf-8')
+        f.seek(0)
+        text2 = f.read().decode('utf-8')
+        assert text_with_empty_comments == text2


### PR DESCRIPTION
Fixes https://bitbucket.org/al45tair/nslocalized/issues/1/make-comments-descriptions-optional by
making the `/* No description */` comment added by `StringTable` optional (and off by default).